### PR TITLE
fix wrong post counts in forums

### DIFF
--- a/forum/views.py
+++ b/forum/views.py
@@ -1,5 +1,5 @@
 """
-All forum logic is kept here - displaying lists of forums, threads 
+All forum logic is kept here - displaying lists of forums, threads
 and posts, adding new threads, and adding replies.
 """
 
@@ -14,9 +14,8 @@ from django.contrib.sites.models import Site
 from django.contrib import comments, messages
 from django.contrib.contenttypes.models import ContentType
 from django.conf import settings
-from django.core.cache import get_cache, InvalidCacheBackendError, ImproperlyConfigured
 
-from forum.models import Forum, Thread, Category
+from forum.models import Forum, Thread, Category, get_forum_cache
 from forum.forms import CreateThreadForm, ReplyForm
 from forum.signals import thread_created
 
@@ -25,14 +24,6 @@ FORUM_PAGINATION = getattr(settings, 'FORUM_PAGINATION', 20)
 LOGIN_URL = getattr(settings, 'LOGIN_URL', '/accounts/login/')
 FORUM_FLOOD_CONTROL = getattr(settings, 'FORUM_FLOOD_CONTROL', {})
 FORUM_POST_EXPIRE_IN = getattr(settings, 'FORUM_POST_EXPIRE_IN', 0)
-
-
-def get_forum_cache():
-    try:
-        cache = get_cache('forum')
-    except (InvalidCacheBackendError, ImproperlyConfigured):
-        cache = None
-    return cache
 
 
 class ForumList(ListView):
@@ -100,13 +91,13 @@ class PostList(ListView):
     template_name='forum/thread.html'
     paginate_by=FORUM_PAGINATION
     model = comments.get_model()
-    
+
     def get(self, *args, **kwargs):
         re = super(PostList, self).get(*args, **kwargs)
         if self.object.forum.slug != self.kwargs.get('forum'):
             return HttpResponseRedirect(self.object.get_absolute_url())
         return re
-        
+
     def get_queryset(self, **kwargs):
         self.object = get_object_or_404(Thread, slug=self.kwargs.get('thread'), forum__site=settings.SITE_ID)
         if not Forum.objects.has_access(self.object.forum, self.request.user):
@@ -240,13 +231,13 @@ def previewthread(request, forum):
     return render_to_response('forum/newthread.html',
         RequestContext(request, {
             'form': form,
-            'forum': f, 
+            'forum': f,
         }))
 
 def newthread(request, forum):
     """
-    Rudimentary post function - this should probably use 
-    newforms, although not sure how that goes when we're updating 
+    Rudimentary post function - this should probably use
+    newforms, although not sure how that goes when we're updating
     two models.
 
     Only allows a user to post if they're logged in.
@@ -255,7 +246,7 @@ def newthread(request, forum):
         return HttpResponseRedirect('%s?next=%s' % (LOGIN_URL, request.path))
 
     f = get_object_or_404(Forum, slug=forum, site=settings.SITE_ID)
-    
+
     if not Forum.objects.has_access(f, request.user):
         return HttpResponseForbidden()
 
@@ -284,7 +275,7 @@ def newthread(request, forum):
             t.latest_post = p
             t.comment = p
             t.save()
-   
+
             " " "
             undecided
             if form.cleaned_data.get('subscribe', False):


### PR DESCRIPTION
Was resetting when a thread was deleted. Changed post and thread counts to properties that are cached for an hour.